### PR TITLE
add timeout to ensure that AnimationEnd event will be triggered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 npm-debug.log
+.idea/

--- a/index.js
+++ b/index.js
@@ -85,7 +85,12 @@ exports.runAnimation = promisify(function (els, opts, cb) {
 
   opts = defaults(opts, found.presets, mainDefaults)
 
+  var ensureAnimationEndWasTriggered = setTimeout(function () {
+      els[0].dispatchEvent(new Event('AnimationEnd'))
+  }, opts.duration + 1000) // add 1000ms is enough for exceptional cases when chrome is frozen.
+
   var animationEnd = function () {
+    clearTimeout(ensureAnimationEndWasTriggered)
     prefixedEvent.remove(els[0], 'AnimationEnd', animationEnd)
     if (opts.resetWhenDone) {
       setAnimationAsTransform(els, {clearAnimations: true})


### PR DESCRIPTION
In some few cases, chrome get frozen and then the AnimationEnd event is never fired.